### PR TITLE
Fix highlighting of exprs that start with `let`

### DIFF
--- a/syntax/ocaml.json
+++ b/syntax/ocaml.json
@@ -1548,7 +1548,7 @@
           "patterns": [{ "include": "#comment" }]
         },
         {
-          "begin": "(?:(?<=(?:[^[:word:]]and|^and|[^[:word:]]let|^let))(?![[:word:]]))|(let)",
+          "begin": "(?:(?<=(?:[^[:word:]]and|^and|[^[:word:]]let|^let))(?![[:word:]]))|(let)(?![a-zA-Z0-9_'])",
           "end": "\\b(?:(and)|(in))\\b|(?=\\}|\\)|\\]|\\b(?:end|class|exception|external|include|inherit|initializer|let|method|module|open|type|val)\\b)",
           "beginCaptures": { "1": { "name": "storage.type markup.underline" } },
           "endCaptures": {


### PR DESCRIPTION
Previously identifiers like `let_propagation` were highlighted
wrong: leading `let` was colored as keyword and everything has
beed broken after that.

Fixed by adding lookahead to grammar rule regexp.