### PR TITLE
Add support for multi workspace workflow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,18 @@
         "--extensionTestsPath=${workspaceFolder}/test/suite/index.js"
       ],
       "outFiles": ["${workspaceFolder}/out/test/**/*.js"]
-    }
+    },
+    {
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/src/**/*.bs.js"
+			]
+		}
   ]
 }

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -6,9 +6,6 @@
   },
   "sources": [
     {
-      "dir": "vendor"
-    },
-    {
       "subdirs": true,
       "dir": "src"
     },

--- a/src/Extension.bs.js
+++ b/src/Extension.bs.js
@@ -3,21 +3,21 @@
 
 var LSP = require("./LSP.bs.js");
 var $$Node = require("./bindings/Node.bs.js");
-var Vscode = require("vscode");
+var Block = require("bs-platform/lib/js/block.js");
 var VscodeLanguageclient = require("vscode-languageclient");
 
 function createClient(id, name, folder) {
-  return LSP.Server.make(folder).then((function (serverOptions) {
-                return Promise.resolve(new VscodeLanguageclient.LanguageClient(id, name, serverOptions, LSP.Client.make(/* () */0)));
+  return LSP.Server.make(folder.uri.fsPath).then((function (serverOptions) {
+                return Promise.resolve(/* Ok */Block.__(0, [new VscodeLanguageclient.LanguageClient(id, name, serverOptions, LSP.Client.make(/* () */0))]));
               }));
 }
 
-function activate(_context) {
-  return createClient("merlin-language-server", "Merlin Language Server", Vscode.workspace.rootPath).then((function (client) {
-                  return Promise.resolve(client.start());
-                })).catch((function (e) {
-                var message = $$Node.$$Error.ofPromiseError(e);
-                return Vscode.window.showErrorMessage("Error: " + (String(message) + ""));
+function activate(context) {
+  return LSP.MultiWorkspace.start(context, /* array */[], (function (_document, folder) {
+                return createClient("merlin-language-server", "Merlin Language Server", folder).catch((function (e) {
+                              var message = $$Node.$$Error.ofPromiseError(e);
+                              return Promise.resolve(/* Error */Block.__(1, [message]));
+                            }));
               }));
 }
 

--- a/src/Extension.re
+++ b/src/Extension.re
@@ -3,29 +3,33 @@ open LSP;
 
 let createClient = (~id, ~name, ~folder) =>
   Js.Promise.(
-    Server.make(folder)
+    Server.make(folder.Folder.uri.fsPath)
     |> then_(serverOptions => {
-         LanguageClient.make(
-           ~id,
-           ~name,
-           ~serverOptions,
-           ~clientOptions=Client.make(),
+         Ok(
+           LanguageClient.make(
+             ~id,
+             ~name,
+             ~serverOptions,
+             ~clientOptions=Client.make(),
+           ),
          )
          |> resolve
        })
   );
 
-let activate = _context => {
-  Js.Promise.(
-    createClient(
-      ~id="merlin-language-server",
-      ~name="Merlin Language Server",
-      ~folder=Workspace.rootPath,
+let activate = context => {
+  MultiWorkspace.start(
+    ~context, ~commands=[||], ~createClient=(_document, folder) => {
+    Js.Promise.(
+      createClient(
+        ~id="merlin-language-server",
+        ~name="Merlin Language Server",
+        ~folder,
+      )
+      |> catch(e => {
+           let message = Bindings.Error.ofPromiseError(e);
+           Js.Promise.resolve(Error(message));
+         })
     )
-    |> then_((client: LanguageClient.t) => client.start(.) |> resolve)
-    |> catch(e => {
-         let message = Bindings.Error.ofPromiseError(e);
-         Window.showErrorMessage({j|Error: $message|j});
-       })
-  );
+  });
 };

--- a/src/bindings/Node.re
+++ b/src/bindings/Node.re
@@ -8,7 +8,7 @@ external processEnv: Js.Dict.t(string) = "env";
 module Error = {
   type t;
   [@bs.new] external make: string => t = "Error";
-  let ofPromiseError = [%raw
+  let ofPromiseError: Js.Promise.error => string = [%raw
     error => "return error.message || 'Unknown error'"
   ];
 };


### PR DESCRIPTION
This PR contains changes needed for multi folder workspaces support. Unfortunately I'm struggling to debug an issue with it. When you open a workspace with at least two folders, the plugin correctly creates a second client for the folder but every subsequent edit for files inside the second folder ends up with:

```
Notification handler 'textDocument/publishDiagnostics' failed with message: Illegal argument: character must be non-negative
```

Does it ring a bell?