### PR TITLE
Fix semver calculation

### DIFF
--- a/src/Esy.bs.js
+++ b/src/Esy.bs.js
@@ -208,7 +208,7 @@ function processDeps(dependenciesJson, folder) {
                     Caml_builtin_exceptions.failure,
                     "'bs-platform' (in dependencies section) was expected to contain a semver string, but it was not!"
                   ]);
-      } else if (Semver.satisfies(match$2[0], ">=6.0.0")) {
+      } else if (Semver.satisfies(Semver.minVersion(match$2[0]), ">=6.0.0")) {
         return dropAnEsyJSON("4.6.x", folder);
       } else {
         return dropAnEsyJSON("4.2.x", folder);

--- a/src/Esy.re
+++ b/src/Esy.re
@@ -127,7 +127,7 @@ let processDeps = (dependenciesJson, folder) => {
         | Some(bsPlatformVersionJson) =>
           switch (Js.Json.classify(bsPlatformVersionJson)) {
           | JSONString(bsPlatformVersion) =>
-            if (Semver.satisfies(bsPlatformVersion, ">=6.0.0")) {
+            if (bsPlatformVersion->Semver.minVersion->Semver.satisfies(">=6.0.0")) {
               dropAnEsyJSON(~folder, ~compilerVersion="4.6.x");
             } else {
               dropAnEsyJSON(~folder, ~compilerVersion="4.2.x");

--- a/src/bindings/Semver.re
+++ b/src/bindings/Semver.re
@@ -1,2 +1,5 @@
 [@bs.module "semver"]
 external satisfies: (string, string) => bool = "satisfies";
+
+[@bs.module "semver"]
+external minVersion: (string) => string = "minVersion";


### PR DESCRIPTION
Fixes https://github.com/arrowresearch/vscode-merlin/issues/12

`semver.satisfies` requires exact version in a first argument, but packages versions are often defined as ranges. This PR fixes it by adding calculation of minimal version possible within the defined range.