### PR TITLE
Various minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _downloads
 .merlin
 lib/
 .bsb.lock
+_esy/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ client/server
 _downloads
 .merlin
 lib/
+.bsb.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ _downloads
 .merlin
 lib/
 .bsb.lock
-_esy/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,18 @@
         "--extensionTestsPath=${workspaceFolder}/test/suite/index.js"
       ],
       "outFiles": ["${workspaceFolder}/out/test/**/*.js"]
+    },
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/src/**/*.bs.js"
+      ]
     }
   ]
 }

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -6,9 +6,6 @@
   },
   "sources": [
     {
-      "dir": "vendor"
-    },
-    {
       "subdirs": true,
       "dir": "src"
     },

--- a/esy.json
+++ b/esy.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#e5e6ebf9dcf157"
+  }
+}

--- a/esy.json
+++ b/esy.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "ocaml": "4.6.x",
+    "@esy-ocaml/reason": "*",
     "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#e5e6ebf9dcf157"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3692,6 +3692,12 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3997,6 +4003,23 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
       }
     },
     "npm-run-path": {
@@ -4306,6 +4329,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
       "dev": true
     },
     "pify": {
@@ -4723,6 +4752,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
@@ -5028,6 +5063,16 @@
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^5.1.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "string.prototype.trimleft": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "test:unit": "jest __tests__",
     "test:opam": "node ./test/runOpamTests.js",
     "test": "npm run test:esy && npm run test:opam && npm run test:bsb",
-    "package": "vsce package"
+    "package": "vsce package",
+    "refmt": "find ./src ./fixtures ./__tests__ -type f -name \"*.re\" | xargs bsrefmt --in-place"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
   "scripts": {
     "clean": "bsb -clean",
     "build": "bsb -make-world",
-    "watch": "tsc -b -w",
+    "watch:bsb": "bsb -make-world -w",
+    "watch:tsc": "tsc -b -w",
+    "watch": "run-p watch:bsb watch:tsc",
     "vscode:prepublish": "npm run build",
     "compile": "tsc -b",
     "test:bsb": "node ./test/runBsbTests.js",
@@ -86,6 +88,7 @@
     "fs-extra": "^8.1.0",
     "jest-cli": "^24.9.0",
     "mocha": "^6.2.2",
+    "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "tslint": "^5.20.1",
     "typescript": "^3.7.3",


### PR DESCRIPTION
Fixing some minor but annoying issues:
— Fix compilation by removing `vendor` from sources
— Add watch script that runs both `bsb` and `tsc` 
— Add formatting script (as formatter in extension doesn't work)
— Add extension run task as suggested by @wokalski
— Add bsb.lock to `gitignore`