### PR TITLE
Add _esy and esy.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ _downloads
 .merlin
 lib/
 .bsb.lock
+_esy/
+esy.lock/


### PR DESCRIPTION
As we dropped `esy.json` to the root, it make sense to gitignore artifacts now