### PR TITLE
Set cwd for ocamlformat

### DIFF
--- a/src/bindings/Node.re
+++ b/src/bindings/Node.re
@@ -177,6 +177,8 @@ module Path = {
   external join: array(string) => string = "join";
 
   [@bs.module "path"] external basename: string => string = "basename";
+
+  [@bs.module "path"] external dirname: string => string = "dirname";
 };
 
 module Response = {

--- a/src/formatters/FormatterUtils.bs.js
+++ b/src/formatters/FormatterUtils.bs.js
@@ -17,7 +17,7 @@ function getFormatterPath(formatter) {
                 var match = process.platform === "win32";
                 var esy = match ? "esy.cmd" : "esy";
                 if (typeof projectType === "number") {
-                  return Promise.resolve("opam exec " + (String(formatter) + ""));
+                  return Promise.resolve("opam exec -- " + (String(formatter) + ""));
                 } else if (projectType.tag) {
                   return Promise.resolve("" + (String(esy) + (" -P " + (String(rootPath) + ("/.vscode/esy " + (String(formatter) + ""))))));
                 } else {

--- a/src/formatters/FormatterUtils.re
+++ b/src/formatters/FormatterUtils.re
@@ -21,7 +21,7 @@ let getFormatterPath = formatter => {
        | ProjectType.Esy(_) => P.resolve({j|$esy $formatter|j})
        | Bsb(_) =>
          P.resolve({j|$esy -P $rootPath/.vscode/esy $formatter|j})
-       | Opam => P.resolve({j|opam exec $formatter|j})
+       | Opam => P.resolve({j|opam exec -- $formatter|j})
        };
      });
 };

--- a/src/formatters/Ocamlformat.bs.js
+++ b/src/formatters/Ocamlformat.bs.js
@@ -17,6 +17,7 @@ function register(param) {
         provideDocumentFormattingEdits: (function ($$document) {
             var filePath = $$document.fileName;
             var fileName = Path.basename($$document.fileName);
+            var cwd = Path.dirname($$document.fileName);
             var match = Vscode.window.activeTextEditor;
             if (match !== undefined) {
               var textEditor = match;
@@ -25,7 +26,9 @@ function register(param) {
               return $$Node.Fs.writeFile(tempFileName, Curry._1(textEditor.document.getText, /* () */0)).then((function (param) {
                                   return FormatterUtils.getFormatterPath("ocamlformat");
                                 })).then((function (formatterPath) {
-                                return $$Node.ChildProcess.exec("" + (String(formatterPath) + (" --enable-outside-detected-project --name=" + (String(filePath) + (" " + (String(tempFileName) + ""))))), { });
+                                return $$Node.ChildProcess.exec("" + (String(formatterPath) + (" --enable-outside-detected-project --name=" + (String(filePath) + (" " + (String(tempFileName) + ""))))), {
+                                            cwd: cwd
+                                          });
                               })).then((function (param) {
                               var textRange = FormatterUtils.getFullTextRange(textEditor.document);
                               $$Node.Fs.unlink(tempFileName);

--- a/src/formatters/Ocamlformat.re
+++ b/src/formatters/Ocamlformat.re
@@ -7,6 +7,7 @@ let register = () => {
       "provideDocumentFormattingEdits": (document: Vscode.Window.document) => {
         let filePath = document.fileName;
         let fileName = Node.Path.basename(document.fileName);
+        let cwd = Node.Path.dirname(document.fileName);
         switch (Vscode.Window.activeTextEditor) {
         | None => Js.Promise.resolve([||])
         | Some(textEditor) =>
@@ -22,7 +23,7 @@ let register = () => {
           |> P.then_(formatterPath => {
                Node.ChildProcess.exec(
                  {j|$formatterPath --enable-outside-detected-project --name=$filePath $tempFileName|j},
-                 Node.ChildProcess.Options.make(),
+                 Node.ChildProcess.Options.make(~cwd, ()),
                );
              })
           |> P.then_(((formattedText, error)) => {

--- a/src/formatters/Refmt.bs.js
+++ b/src/formatters/Refmt.bs.js
@@ -19,6 +19,7 @@ function register(param) {
       }, {
         provideDocumentFormattingEdits: (function ($$document) {
             var fileName = Path.basename($$document.fileName);
+            var cwd = Path.dirname($$document.fileName);
             var match = Vscode.window.activeTextEditor;
             if (match !== undefined) {
               var textEditor = match;
@@ -28,7 +29,9 @@ function register(param) {
               return $$Node.Fs.writeFile(tempFileName, Curry._1(textEditor.document.getText, /* () */0)).then((function (param) {
                                   return FormatterUtils.getFormatterPath("refmt");
                                 })).then((function (formatterPath) {
-                                return $$Node.ChildProcess.exec("" + (String(formatterPath) + (" " + (String(tempFileName) + (" " + (String(refmtWidthArg) + ""))))), { });
+                                return $$Node.ChildProcess.exec("" + (String(formatterPath) + (" " + (String(tempFileName) + (" " + (String(refmtWidthArg) + ""))))), {
+                                            cwd: cwd
+                                          });
                               })).then((function (param) {
                               var textRange = FormatterUtils.getFullTextRange(textEditor.document);
                               $$Node.Fs.unlink(tempFileName);

--- a/src/formatters/Refmt.re
+++ b/src/formatters/Refmt.re
@@ -12,6 +12,7 @@ let register = () => {
     {
       "provideDocumentFormattingEdits": (document: Vscode.Window.document) => {
         let fileName = Node.Path.basename(document.fileName);
+        let cwd = Node.Path.dirname(document.fileName);
         switch (Vscode.Window.activeTextEditor) {
         | None => Js.Promise.resolve([||])
         | Some(textEditor) =>
@@ -27,7 +28,7 @@ let register = () => {
           |> P.then_(formatterPath => {
                Node.ChildProcess.exec(
                  {j|$formatterPath $tempFileName $refmtWidthArg|j},
-                 Node.ChildProcess.Options.make(),
+                 Node.ChildProcess.Options.make(~cwd, ()),
                )
              })
           |> P.then_(((formattedText, _)) => {


### PR DESCRIPTION
Without cwd esy doesn't really work (not sure how it worked before):  
```
Error: Command failed: esy ocamlformat --enable-outside-detected-project --name=/Users/rusty/code/ahrefs/frontend/backend/api/src/api.ml /var/folders/ck/y9xmnkwj3_dcj8slzpqtp2s80000gn/T/vscode-merlin-ocamlformat-76753f09-c5ac-4396-a419-8347690a27b6-api.ml
error: No esy project found (was looking from . and up)
```

This PR fixes that by setting cwd.

Also, adding escaping for `opam exec`, otherwise it doesn't really work either :)